### PR TITLE
Add abort() stub for context methods

### DIFF
--- a/source.js
+++ b/source.js
@@ -12,10 +12,10 @@ export default class StubbedRelayContainer extends React.Component {
   getChildContext() {
     return {
       relay: {
-        forceFetch: () => {},
+        forceFetch: () => ({ abort: () => {} }),
         getFragmentResolver: () => {},
         getStoreData: () => {},
-        primeCache: () => {}
+        primeCache: () => ({ abort: () => {} })
       },
       route: { name: 'string', params:{}, useMockData: true, queries: {}}
     };


### PR DESCRIPTION
I have a component that does `this.props.relay.setVariables` as part of its `componentDidMount`, and some other components that do the same when there is user interaction.

The stubbing of `primeCache` in `StubbedRelayContainer` handles the call well, but when we call `setVariables`, Relay also [saves](https://github.com/facebook/relay/blob/7110c68f437391ad1ee54ab2c84fd8896a8662fb/src/container/RelayContainer.js#L357) the return value of `primeCache` as a property `pending`. When the component gets unmounted (for example when we view a different story), it [calls](https://github.com/facebook/relay/blob/7110c68f437391ad1ee54ab2c84fd8896a8662fb/src/container/RelayContainer.js#L544) `pending.request.abort()`, which causes an error as `pending.request.abort` is undefined.

This is probably not that big of a problem for web-based React apps, but it does cause React Native apps to get a red box error, which is pretty annoying when browsing through storybook stories.