### PR TITLE
PropTypes are required for context. Fixed relay object shape

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -38,16 +42,22 @@ var StubbedRelayContainer = function (_React$Component) {
     value: function getChildContext() {
       return {
         relay: {
-          forceFetch: function forceFetch() {
-            return { abort: function abort() {} };
+          environment: {
+            applyMutation: function applyMutation() {},
+            sendMutation: function sendMutation() {},
+            forceFetch: function forceFetch() {
+              return { abort: function abort() {} };
+            },
+            getFragmentResolver: function getFragmentResolver() {},
+            getStoreData: function getStoreData() {},
+            primeCache: function primeCache() {
+              return { abort: function abort() {} };
+            }
           },
-          getFragmentResolver: function getFragmentResolver() {},
-          getStoreData: function getStoreData() {},
-          primeCache: function primeCache() {
-            return { abort: function abort() {} };
-          }
+          variables: {}
         },
-        route: { name: 'string', params: {}, useMockData: true, queries: {} }
+        route: { name: 'string', params: {}, useMockData: true, queries: {} },
+        useFakeData: true
       };
     }
 
@@ -79,4 +89,11 @@ var StubbedRelayContainer = function (_React$Component) {
 }(_react2.default.Component);
 
 exports.default = StubbedRelayContainer;
+
+
+StubbedRelayContainer.childContextTypes = {
+  relay: _propTypes2.default.object,
+  route: _propTypes2.default.object,
+  useFakeData: _propTypes2.default.bool
+};
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,7 @@
     "mocha": "^2.5.3",
     "react": "^15.5.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }

--- a/source.js
+++ b/source.js
@@ -2,6 +2,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // Emulates a Relay-compatible container, passing the data in directly.
 // It's hard to know how well this can work for complicated examples. However,
@@ -12,12 +13,18 @@ export default class StubbedRelayContainer extends React.Component {
   getChildContext() {
     return {
       relay: {
-        forceFetch: () => ({ abort: () => {} }),
-        getFragmentResolver: () => {},
-        getStoreData: () => {},
-        primeCache: () => ({ abort: () => {} })
+        environment: {
+          applyMutation: () => {},
+          sendMutation: () => {},
+          forceFetch: () => ({ abort: () => {} }),
+          getFragmentResolver: () => {},
+          getStoreData: () => {},
+          primeCache: () => ({ abort: () => {} })
+        },
+        variables: {}
       },
-      route: { name: 'string', params:{}, useMockData: true, queries: {}}
+      route: { name: 'string', params: {}, useMockData: true, queries: {} },
+      useFakeData: true
     };
   }
 
@@ -32,3 +39,9 @@ export default class StubbedRelayContainer extends React.Component {
   hasFragment() {}
   hasVariable() {}
 }
+
+StubbedRelayContainer.childContextTypes = {
+    relay: PropTypes.object,
+    route: PropTypes.object,
+    useFakeData: PropTypes.bool
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,7 +1387,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
So PropTypes are required for context types it turns out. Also the shape wasn't exactly correct for `react-relay@1.0.0` for classic Relay so I fixed that as well. I haven't tested if it's backwards compatible though. Here's the [check](https://github.com/facebook/relay/blob/9e6f14d388184c48eef149ae979346f25ffea866/packages/react-relay/classic/store/isClassicRelayContext.js#L23-L31) `react-relay` does. You'll notice it does a check for [`isClassicRelayEnvironment `](https://github.com/facebook/relay/blob/9e6f14d388184c48eef149ae979346f25ffea866/packages/react-relay/classic/store/isClassicRelayEnvironment.js)